### PR TITLE
Use maintained mlc action and skip Yanning's site

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - name: INstall Dependencies
+      - name: Install Dependencies
         run: bun install
       - name: Generate Static Website
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Verify markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
       - name: Bun Setup
         uses: oven-sh/setup-bun@v1
         with:

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Verify markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
       - name: Bun Setup
         uses: oven-sh/setup-bun@v1
         with:

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -5,6 +5,9 @@
       },
       {
         "pattern": "^https://linkedin.com"
+      },
+      {
+        "pattern": "^https://yanningchen.me"
       }
     ],
     "replacementPatterns": [


### PR DESCRIPTION
Looks like builds are still failing because Yanning's site is returning a 403. It responds successful for me, so my best guess is that she has something set up to block requests from certain IPs, which includes wherever GitHub is running actions. I've added an ignore pattern for her site so the check will just skip it, and I also switched the action that does the check to a maintained version which should do the same thing.